### PR TITLE
add support for Farbic Permissions API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ repositories {
     // for more information about repositories.
 
     maven { url "https://maven.shedaniel.me/" }
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 dependencies {
@@ -29,6 +30,9 @@ dependencies {
     modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
+
+    // Fabric Permissions API
+    include(modImplementation('me.lucko:fabric-permissions-api:0.2-SNAPSHOT'))
 }
 
 processResources {

--- a/src/main/java/io/github/steveplays28/restartserver/commands/RestartCommand.java
+++ b/src/main/java/io/github/steveplays28/restartserver/commands/RestartCommand.java
@@ -2,6 +2,7 @@ package io.github.steveplays28.restartserver.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import io.github.steveplays28.restartserver.RestartServer;
+import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
@@ -16,7 +17,7 @@ public class RestartCommand {
 	public static final int PERMISSION_LEVEL = 4;
 
 	public static LiteralArgumentBuilder<ServerCommandSource> register() {
-		return CommandManager.literal(NAME).executes(ctx -> execute(ctx.getSource())).requires((ctx) -> ctx.hasPermissionLevel(PERMISSION_LEVEL));
+		return CommandManager.literal(NAME).executes(ctx -> execute(ctx.getSource())).requires((ctx) -> Permissions.check(ctx, "restart_server.commands."+NAME, PERMISSION_LEVEL));
 	}
 
 	public static int execute(ServerCommandSource source) {


### PR DESCRIPTION
permission node is `restart_server.commands.restart`, default required permission level is still 4
#16 